### PR TITLE
Fix request timeouts under concurrent load

### DIFF
--- a/internal/api/rest/server.go
+++ b/internal/api/rest/server.go
@@ -45,7 +45,7 @@ func NewServer(c cache.Cache, s Scraper, g Generator, ipFilter IPFilter, port st
 			Handler:           nil,               // Will be set in Run
 			ReadHeaderTimeout: 10 * time.Second,  // Mitigate Slowloris
 			ReadTimeout:       30 * time.Second,  // Time to read entire request (including body)
-			WriteTimeout:      30 * time.Second,  // Time to write response
+			WriteTimeout:      300 * time.Second, // Time to process request and write response (includes semaphore wait + scraping)
 			IdleTimeout:       120 * time.Second, // Keep-alive timeout
 		},
 	}

--- a/internal/api/rest/telegram.go
+++ b/internal/api/rest/telegram.go
@@ -155,7 +155,7 @@ func (h *telegramHandler) serveContent(w http.ResponseWriter, content []byte, fo
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write(content); err != nil {
-		handleBadErrorResponse(err, content)
+		h.logger.Error("Failed to write response", "error", err, "content_length", len(content))
 	}
 }
 

--- a/internal/feed/extract.go
+++ b/internal/feed/extract.go
@@ -1,8 +1,6 @@
 package feed
 
 import (
-	"io"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -330,11 +328,12 @@ func extractImageTypeFromURL(url string) string {
 
 func getImageSize(imageURL string) int64 {
 	logger := app.Logger()
+
 	// nolint: gosec
-	res, err := httpClient.Get(imageURL)
+	res, err := httpClient.Head(imageURL)
 
 	if err != nil {
-		logger.Error("Could not download an image",
+		logger.Error("Could not get image size",
 			"imageUrl", imageURL,
 			"error", err)
 
@@ -343,31 +342,9 @@ func getImageSize(imageURL string) int64 {
 
 	defer res.Body.Close()
 
-	tmpFile, err := os.CreateTemp(tmpPath, "enclosure_*")
-
-	if err != nil {
-		logger.Error("Could not create a temp file",
-			"imageUrl", imageURL,
-			"error", err)
-
-		return 0
+	if res.StatusCode >= 200 && res.StatusCode < 300 && res.ContentLength > 0 {
+		return res.ContentLength
 	}
 
-	defer func() {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
-	}()
-
-	n, err := io.Copy(tmpFile, res.Body)
-
-	if err != nil {
-		logger.Error("Could not save an image into tmp file",
-			"tmpFilename", tmpFile.Name(),
-			"imageUrl", imageURL,
-			"error", err)
-
-		return 0
-	}
-
-	return n
+	return 0
 }

--- a/internal/feed/scraper.go
+++ b/internal/feed/scraper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nDmitry/tgfeed/internal/entity"
 )
 
-const tmpPath = "/tmp"
 const tgProtocolDefault = "https"
 const tgDomainDefault = "t.me"
 const userAgentDefault = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Image size detection now uses HEAD requests instead of full downloads, reducing bandwidth.

* **Bug Fixes**
  * Extended server request timeout from 30s to 300s to accommodate longer operations.
  * Improved logging for response write failures to aid troubleshooting.

* **Chores**
  * Removed unused configuration/constants and eliminated unnecessary file I/O.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->